### PR TITLE
review C (debugging with GDB) runner

### DIFF
--- a/runners/C (GDB Debugging).run
+++ b/runners/C (GDB Debugging).run
@@ -1,0 +1,17 @@
+// For more information see http://docs.c9.io:8080/#!/api/run-method-run
+// put me in .c9/runners/
+{
+  "cmd": [
+    "sh",
+    "-c",
+    "/usr/bin/make $file_base_name && gdbserver :15470 $file_path/$file_base_name $args"
+  ],
+
+  "info": "Compiling $file ...",
+  "debugport": 15470,
+  "debugger": "gdb",
+  "executable": "$file_path/$file_base_name",
+  "maxdepth": 50,
+  "env": {},
+  "selector": "^.*\\.c$"
+}


### PR DESCRIPTION
This is part of beta 1 for a GDB-based C debugger plugin. See:
https://github.com/c9/c9.ide.run.debug/pull/4
For required changes to debugger plugin to enable this runner to work.

This request isn't necessarily to merge into the c9 repo but to begin the review process. We'd like to beta test this plugin with real world usage for a short while before declaring it stable.

We may wish to consider the implications of this runner to the "C (simple)" runner if this is eventually merged into the repo.
